### PR TITLE
强化暗色内联样式避免闪烁

### DIFF
--- a/Enhanced-Script_Auto.js
+++ b/Enhanced-Script_Auto.js
@@ -13,6 +13,7 @@
 // @match        *://upload.e-hentai.org/*
 // @grant        none
 // @license      MIT
+// @run-at       document-start
 // ==/UserScript==
 
 (function () {
@@ -42,6 +43,49 @@
   let currentMode;
   let systemListenerAttached = false;
   let darkToggleBtn;
+  let toTopBtn;
+  let toBottomBtn;
+  let pendingInlineBodyUpdate = false;
+
+  const setImportantStyle = (el, prop, value) => {
+    if (!el) return;
+    if (value === null) {
+      el.style.removeProperty(prop);
+    } else {
+      el.style.setProperty(prop, value, 'important');
+    }
+  };
+
+  const updateInlineTheme = (isDark) => {
+    const root = document.documentElement;
+    if (isDark) {
+      setImportantStyle(root, 'background-color', DARK_BG);
+      setImportantStyle(root, 'background', DARK_BG);
+      setImportantStyle(root, 'color', DARK_TEXT);
+      setImportantStyle(root, 'color-scheme', 'dark');
+    } else {
+      setImportantStyle(root, 'background-color', null);
+      setImportantStyle(root, 'background', null);
+      setImportantStyle(root, 'color', null);
+      setImportantStyle(root, 'color-scheme', null);
+    }
+
+    const body = document.body;
+    if (body) {
+      if (isDark) {
+        setImportantStyle(body, 'background-color', DARK_BG);
+        setImportantStyle(body, 'background', DARK_BG);
+        setImportantStyle(body, 'color', DARK_TEXT);
+      } else {
+        setImportantStyle(body, 'background-color', null);
+        setImportantStyle(body, 'background', null);
+        setImportantStyle(body, 'color', null);
+      }
+      pendingInlineBodyUpdate = false;
+    } else {
+      pendingInlineBodyUpdate = isDark;
+    }
+  };
 
   const readCookie = (k) =>
     document.cookie.split('; ').find(s => s.startsWith(k + '='))?.split('=')[1];
@@ -52,7 +96,11 @@
     document.cookie = `${k}=${v}; expires=${d.toUTCString()}; path=/` + (domain ? `; domain=${domain}` : '');
   };
 
-  const applyDark = (on) => document.documentElement.classList.toggle('eh-dark', !!on);
+  const applyDark = (on) => {
+    const isDark = !!on;
+    document.documentElement.classList.toggle('eh-dark', isDark);
+    updateInlineTheme(isDark);
+  };
 
   const setPref = (on) => {
     localStorage.setItem(LS_KEY, on ? '1' : '0');
@@ -146,10 +194,29 @@
     return MODE_AUTO;
   };
 
-  const initDarkPref = () => {
-    const initialMode = readInitialMode();
-    applyMode(initialMode, { persist: true });
+  const initDarkPref = (initialMode) => {
+    const modeToApply = initialMode ?? readInitialMode();
+    applyMode(modeToApply, { persist: true });
   };
+
+  const preApplyInitialMode = () => {
+    const mode = readInitialMode();
+    currentMode = mode;
+    const effective = resolveEffectiveMode(mode);
+    applyDark(effective === MODE_DARK);
+    return mode;
+  };
+
+  const preAppliedMode = preApplyInitialMode();
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (pendingInlineBodyUpdate && document.documentElement.classList.contains('eh-dark')) {
+      updateInlineTheme(true);
+    }
+  });
+  if (document.readyState !== 'loading' && pendingInlineBodyUpdate && document.documentElement.classList.contains('eh-dark')) {
+    updateInlineTheme(true);
+  }
 
   /* =========================
    *         样式
@@ -376,7 +443,7 @@
 
   const style = document.createElement('style');
   style.textContent = styles;
-  document.head.appendChild(style);
+  (document.head || document.documentElement).appendChild(style);
 
   /* =========================
    *   悬浮：顶 / 底 / 暗色开关
@@ -389,21 +456,14 @@
     document.body.appendChild(el);
     return el;
   };
-  const toTopBtn = makeBtn('eh-to-top-btn', '▲', '回到顶部');
-  const toBottomBtn = makeBtn('eh-to-bottom-btn', '▼', '直达底部');
-  darkToggleBtn = makeBtn('eh-dark-toggle-btn', '🌓', '主题模式：系统/暗色/亮色（快捷键：d）', {display:'flex'});
-
-  toTopBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
-  toBottomBtn.addEventListener('click', () => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }));
-
   const onScroll = () => {
+    if (!toTopBtn || !toBottomBtn) return;
     const h = document.documentElement.scrollHeight;
     const ch = document.documentElement.clientHeight;
     const t = window.scrollY || document.documentElement.scrollTop;
     toTopBtn.style.display = t > 200 ? 'flex' : 'none';
     toBottomBtn.style.display = (t + ch >= h - 5) ? 'none' : 'flex';
   };
-  window.addEventListener('scroll', onScroll, { passive: true });
 
   /* =========================
    *     暗色开关（仅小写 d）
@@ -415,9 +475,36 @@
     fixMonsterBox();
     fixFavoritesUI();
   };
-  darkToggleBtn.addEventListener('click', cycleMode);
-  initDarkPref();
-  onScroll();
+
+  let bootstrapped = false;
+  const bootstrap = () => {
+    if (bootstrapped) return;
+    if (!document.body) {
+      if (document.readyState === 'loading') return;
+      requestAnimationFrame(bootstrap);
+      return;
+    }
+
+    bootstrapped = true;
+    toTopBtn = makeBtn('eh-to-top-btn', '▲', '回到顶部');
+    toBottomBtn = makeBtn('eh-to-bottom-btn', '▼', '直达底部');
+    darkToggleBtn = makeBtn('eh-dark-toggle-btn', '🌓', '主题模式：系统/暗色/亮色（快捷键：d）', {display:'flex'});
+
+    toTopBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    toBottomBtn.addEventListener('click', () => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }));
+    darkToggleBtn.addEventListener('click', cycleMode);
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    initDarkPref(preAppliedMode);
+    onScroll();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrap);
+  } else {
+    bootstrap();
+  }
 
   /* =========================
    *   Monster Encounter 适配


### PR DESCRIPTION
## Summary
- 新增 `setImportantStyle` 助手并用 `!important` 方式提前给 html/body 套用暗色背景与文字颜色
- 同步加上 `background` 与 `color-scheme` 的强制内联设置，避免外部样式覆盖导致加载瞬间闪白

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6fbf41048331b2b08f32f123a4ac