### PR TITLE
延迟展示直至暗色内联就绪

### DIFF
--- a/Enhanced-Script_Auto.js
+++ b/Enhanced-Script_Auto.js
@@ -2,7 +2,7 @@
 // @name         E-Hentai 实用增强：回顶/到底 + [ ] 翻页 + 自动主题切换
 // @name:en      E-Hentai Tweaks: Scroll Buttons + [ ] Paging + Auto Theme Switching
 // @namespace    https://greasyfork.org/users/1508871-vesper233
-// @version      4.3
+// @version      4.3.2
 // @description  悬浮回顶/到底；全站 [ 与 ] 快捷翻页；自动主题切换
 // @description:en   Scroll to Top/Bottom buttons; [ and ] for Prev/Next page; Auto Theme Switching
 // @author       Vesper233
@@ -13,6 +13,7 @@
 // @match        *://upload.e-hentai.org/*
 // @grant        none
 // @license      MIT
+// @run-at       document-start
 // ==/UserScript==
 
 (function () {
@@ -42,6 +43,102 @@
   let currentMode;
   let systemListenerAttached = false;
   let darkToggleBtn;
+  let toTopBtn;
+  let toBottomBtn;
+  let pendingInlineBodyUpdate = null;
+  let pendingInlineBodyRaf = 0;
+  let docHiddenForDarkInit = false;
+  let revealAwaitingBody = false;
+
+  const setImportantStyle = (el, prop, value) => {
+    if (!el) return;
+    if (value === null) {
+      el.style.removeProperty(prop);
+    } else {
+      el.style.setProperty(prop, value, 'important');
+    }
+  };
+
+  const hideDocumentForDarkInit = () => {
+    if (docHiddenForDarkInit) return;
+    const root = document.documentElement;
+    if (!root) return;
+    setImportantStyle(root, 'visibility', 'hidden');
+    docHiddenForDarkInit = true;
+    revealAwaitingBody = false;
+  };
+
+  const tryRevealDocument = () => {
+    if (!docHiddenForDarkInit) return;
+    if (pendingInlineBodyUpdate !== null) {
+      revealAwaitingBody = true;
+      return;
+    }
+    docHiddenForDarkInit = false;
+    revealAwaitingBody = false;
+    const root = document.documentElement;
+    if (!root) return;
+    setImportantStyle(root, 'visibility', 'visible');
+    requestAnimationFrame(() => {
+      setImportantStyle(root, 'visibility', null);
+    });
+  };
+
+  const applyInlineBodyTheme = (isDark) => {
+    const body = document.body;
+    if (!body) return false;
+    if (isDark) {
+      setImportantStyle(body, 'background-color', DARK_BG);
+      setImportantStyle(body, 'background', DARK_BG);
+      setImportantStyle(body, 'color', DARK_TEXT);
+    } else {
+      setImportantStyle(body, 'background-color', null);
+      setImportantStyle(body, 'background', null);
+      setImportantStyle(body, 'color', null);
+    }
+    return true;
+  };
+
+  const flushPendingInlineBodyUpdate = () => {
+    pendingInlineBodyRaf = 0;
+    if (pendingInlineBodyUpdate === null) return;
+    if (applyInlineBodyTheme(pendingInlineBodyUpdate)) {
+      pendingInlineBodyUpdate = null;
+      if (revealAwaitingBody) {
+        tryRevealDocument();
+      }
+    } else {
+      scheduleInlineBodyUpdate();
+    }
+  };
+
+  const scheduleInlineBodyUpdate = () => {
+    if (pendingInlineBodyRaf) return;
+    pendingInlineBodyRaf = requestAnimationFrame(flushPendingInlineBodyUpdate);
+  };
+
+  const updateInlineTheme = (isDark) => {
+    const root = document.documentElement;
+    if (isDark) {
+      setImportantStyle(root, 'background-color', DARK_BG);
+      setImportantStyle(root, 'background', DARK_BG);
+      setImportantStyle(root, 'color', DARK_TEXT);
+      setImportantStyle(root, 'color-scheme', 'dark');
+    } else {
+      setImportantStyle(root, 'background-color', null);
+      setImportantStyle(root, 'background', null);
+      setImportantStyle(root, 'color', null);
+      setImportantStyle(root, 'color-scheme', null);
+    }
+
+    if (applyInlineBodyTheme(isDark)) {
+      pendingInlineBodyUpdate = null;
+    } else {
+      pendingInlineBodyUpdate = isDark;
+      scheduleInlineBodyUpdate();
+    }
+    tryRevealDocument();
+  };
 
   const readCookie = (k) =>
     document.cookie.split('; ').find(s => s.startsWith(k + '='))?.split('=')[1];
@@ -52,7 +149,11 @@
     document.cookie = `${k}=${v}; expires=${d.toUTCString()}; path=/` + (domain ? `; domain=${domain}` : '');
   };
 
-  const applyDark = (on) => document.documentElement.classList.toggle('eh-dark', !!on);
+  const applyDark = (on) => {
+    const isDark = !!on;
+    document.documentElement.classList.toggle('eh-dark', isDark);
+    updateInlineTheme(isDark);
+  };
 
   const setPref = (on) => {
     localStorage.setItem(LS_KEY, on ? '1' : '0');
@@ -146,10 +247,28 @@
     return MODE_AUTO;
   };
 
-  const initDarkPref = () => {
-    const initialMode = readInitialMode();
-    applyMode(initialMode, { persist: true });
+  const initDarkPref = (initialMode) => {
+    const modeToApply = initialMode ?? readInitialMode();
+    applyMode(modeToApply, { persist: true });
   };
+
+  const preApplyInitialMode = (mode) => {
+    const initial = mode ?? readInitialMode();
+    currentMode = initial;
+    const effective = resolveEffectiveMode(initial);
+    applyDark(effective === MODE_DARK);
+    return initial;
+  };
+
+  const initialMode = readInitialMode();
+  if (resolveEffectiveMode(initialMode) === MODE_DARK) {
+    hideDocumentForDarkInit();
+  }
+  const preAppliedMode = preApplyInitialMode(initialMode);
+
+  if (pendingInlineBodyUpdate !== null) {
+    flushPendingInlineBodyUpdate();
+  }
 
   /* =========================
    *         样式
@@ -376,7 +495,7 @@
 
   const style = document.createElement('style');
   style.textContent = styles;
-  document.head.appendChild(style);
+  (document.head || document.documentElement).appendChild(style);
 
   /* =========================
    *   悬浮：顶 / 底 / 暗色开关
@@ -389,21 +508,14 @@
     document.body.appendChild(el);
     return el;
   };
-  const toTopBtn = makeBtn('eh-to-top-btn', '▲', '回到顶部');
-  const toBottomBtn = makeBtn('eh-to-bottom-btn', '▼', '直达底部');
-  darkToggleBtn = makeBtn('eh-dark-toggle-btn', '🌓', '主题模式：系统/暗色/亮色（快捷键：d）', {display:'flex'});
-
-  toTopBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
-  toBottomBtn.addEventListener('click', () => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }));
-
   const onScroll = () => {
+    if (!toTopBtn || !toBottomBtn) return;
     const h = document.documentElement.scrollHeight;
     const ch = document.documentElement.clientHeight;
     const t = window.scrollY || document.documentElement.scrollTop;
     toTopBtn.style.display = t > 200 ? 'flex' : 'none';
     toBottomBtn.style.display = (t + ch >= h - 5) ? 'none' : 'flex';
   };
-  window.addEventListener('scroll', onScroll, { passive: true });
 
   /* =========================
    *     暗色开关（仅小写 d）
@@ -415,9 +527,36 @@
     fixMonsterBox();
     fixFavoritesUI();
   };
-  darkToggleBtn.addEventListener('click', cycleMode);
-  initDarkPref();
-  onScroll();
+
+  let bootstrapped = false;
+  const bootstrap = () => {
+    if (bootstrapped) return;
+    if (!document.body) {
+      if (document.readyState === 'loading') return;
+      requestAnimationFrame(bootstrap);
+      return;
+    }
+
+    bootstrapped = true;
+    toTopBtn = makeBtn('eh-to-top-btn', '▲', '回到顶部');
+    toBottomBtn = makeBtn('eh-to-bottom-btn', '▼', '直达底部');
+    darkToggleBtn = makeBtn('eh-dark-toggle-btn', '🌓', '主题模式：系统/暗色/亮色（快捷键：d）', {display:'flex'});
+
+    toTopBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    toBottomBtn.addEventListener('click', () => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' }));
+    darkToggleBtn.addEventListener('click', cycleMode);
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    initDarkPref(preAppliedMode);
+    onScroll();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrap);
+  } else {
+    bootstrap();
+  }
 
   /* =========================
    *   Monster Encounter 适配


### PR DESCRIPTION
## Summary
- 引入 applyInlineBodyTheme/scheduleInlineBodyUpdate，利用 requestAnimationFrame 在 body 出现的第一时间写入暗色内联样式
- 仅在需要时刷新待处理标记，避免延迟到 DOMContentLoaded 才覆写亮色导致的短暂闪烁
- 在初始暗色模式时临时隐藏页面，等待内联样式写入成功后再显现，进一步消除亮色闪屏
- bump userscript 版本至 4.3.2

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd6fbf41048331b2b08f32f123a4ac